### PR TITLE
ci: Add reusable web files for semantic release

### DIFF
--- a/web/generate-bundle-and-commit.sh
+++ b/web/generate-bundle-and-commit.sh
@@ -1,0 +1,6 @@
+# This file generates and commits bundled files as part of the mParticle JS SDK ecosystem's release process.
+
+echo '---------- Begin generate latest bundle ----------'
+npm run build
+git add dist -f
+git commit -m 'chore(build): Generate latest bundle [skip ci]'

--- a/web/release.config.js
+++ b/web/release.config.js
@@ -1,0 +1,47 @@
+// This is a semantic-release config file that the mParticle JS SDK ecosystem uses as part of its release process.
+
+module.exports = {
+  branches: ["master"],
+  tagFormat: "v${version}",
+  plugins: [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        preset: "angular",
+      },
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        preset: "angular",
+      },
+    ],
+    [
+      "@semantic-release/changelog",
+      {
+        changelogFile: "CHANGELOG.md",
+      },
+    ],
+    ["@semantic-release/npm"],
+    [
+      "@semantic-release/exec",
+      {
+        prepareCmd: "sh generate-bundle-and-commit.sh",
+      },
+    ],
+    [
+      "@semantic-release/github",
+      {
+        assets: ["dist"],
+      },
+    ],
+    [
+      "@semantic-release/git",
+      {
+        assets: ["package.json", "package-lock.json", "CHANGELOG.md"],
+        message:
+          "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
+      },
+    ],
+  ],
+};


### PR DESCRIPTION
## Summary
These files will be curl-ed in by the mParticle core web sdk and web kits as part of the semantic release process.  They are pretty much a copy of the current files that live here and are working.

## Testing Plan
I ran these files in a test account to ensure the release worked properly and it did.  [See here](https://github.com/rmi22186/rob-test-kit-semantic-release/actions/runs/1422877461) for a successful action.