### PR TITLE
ci: allow daily android kit cron to be called from workflow

### DIFF
--- a/.github/workflows/android-kit-daily.yml
+++ b/.github/workflows/android-kit-daily.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+  # Allow to be called from a workflow child  
+  workflow_call: 
+
   # Allow workflow to be manually run from the GitHub UI
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- Fix android kit daily cron

## Testing Plan
- Test daily cron from workflow

