### PR TITLE
ci: add security workflow to scan for hardcoded secrets

### DIFF
--- a/.github/workflows/security-hardcoded-secrets.yml
+++ b/.github/workflows/security-hardcoded-secrets.yml
@@ -1,0 +1,43 @@
+name: "Security Hardcored Secrets"
+on:
+  workflow_call:
+jobs:
+  trufflehog:
+    name: "Run TruffleHog to enumerate possible secrets leakage"
+    runs-on: ubuntu-latest
+    env:
+      branch: ${{ github.head_ref }}
+      version: latest
+    steps:
+      - name: "Setup targeted TruffleHog version"
+        run: |
+          curl --location "https://api.github.com/repos/trufflesecurity/trufflehog/releases" -o ./releases.json
+          remotes=$(cat ./releases.json | grep "browser_download_url.*linux_amd64" | cut -d : -f 2,3 | tr -d \")
+
+          for remote in $remotes; do
+              if [ "$version" = "latest" ]; then
+                  target="$remote"
+                  break
+              fi
+
+              $remote_version=$(echo "$remote" | cut -d "/" -f 8)
+              if [ "$version" = "$remote_version" ]; then
+                  target="$remote"
+                  break
+              fi
+          done
+
+          [ -d /tmp/bin ] || mkdir /tmp/bin
+          path="/tmp/bin/trufflehog.tar.gz"
+          curl --location "$target" -o "$path"
+          tar zxf "$path" -C "/tmp/bin"
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
+
+      - name: "Run TruffleHog"
+        run: |
+          /tmp/bin/trufflehog git file://./ --branch "$branch" --fail


### PR DESCRIPTION
## Summary
- Adds a security workflow for [TruffleHog](https://github.com/trufflesecurity/trufflehog) for searching possible hardcoded secrets.

## Master Issue
Closes https://go.mparticle.com/work/SIG-478