### PR TITLE
ci: Add reusable security checks

### DIFF
--- a/.github/workflows/daily-cron.yml
+++ b/.github/workflows/daily-cron.yml
@@ -32,3 +32,29 @@ jobs:
 
       - name: Get output
         run: "echo 'Deleted branches: ${{ steps.delete.outputs.deleted_branches }}'"
+
+  run-semgrep-full:
+    name: "Run Semgrep over entire repo"
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v3
+
+      - name: "Get Semgrep configs"
+        run: |
+          REPO_NAME=${{ github.event.repository.name }}
+
+          if [[ $REPO_NAME =~ "/android/" ]]; then
+              echo "SEMGREP_RULES=p/java p/kotlin p/javascript r/bash r/yaml" >> $GITHUB_ENV
+          elif [[ $REPO_NAME =~ "/apple/" ]]; then
+              echo "SEMGREP_RULES=p/ci p/javascript p/ruby r/bash r/yaml" >> $GITHUB_ENV
+          elif [[ $REPO_NAME =~ "/web/" || $REPO_NAME =~ "/node/" ]]; then
+              echo "SEMGREP_RULES=p/javascript p/typescript" >> $GITHUB_ENV
+          else
+              echo "SEMGREP_RULES=auto" >> $GITHUB_ENV
+          fi
+
+      - name: "Run Semgrep"
+        run: "semgrep --config=${{ env.SEMGREP_RULES}} ."

--- a/.github/workflows/daily-cron.yml
+++ b/.github/workflows/daily-cron.yml
@@ -46,11 +46,11 @@ jobs:
         run: |
           REPO_NAME=${{ github.event.repository.name }}
 
-          if [[ $REPO_NAME =~ "/android/" ]]; then
+          if [[ $REPO_NAME =~ "android" ]]; then
               echo "SEMGREP_RULES=p/java p/kotlin p/javascript r/bash r/yaml" >> $GITHUB_ENV
-          elif [[ $REPO_NAME =~ "/apple/" ]]; then
+          elif [[ $REPO_NAME =~ "apple" ]]; then
               echo "SEMGREP_RULES=p/ci p/javascript p/ruby r/bash r/yaml" >> $GITHUB_ENV
-          elif [[ $REPO_NAME =~ "/web/" || $REPO_NAME =~ "/node/" ]]; then
+          elif [[ $REPO_NAME =~ "web" || $REPO_NAME =~ "node" ]]; then
               echo "SEMGREP_RULES=p/javascript p/typescript" >> $GITHUB_ENV
           else
               echo "SEMGREP_RULES=auto" >> $GITHUB_ENV

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -21,9 +21,9 @@ jobs:
           REPO_NAME=${{ github.event.repository.name }}
 
           if [[ $REPO_NAME =~ "/android/" ]]; then
-              SEMGREP_RULES="p/java p/kotlin p/javascript p/bash p/yaml"
+              SEMGREP_RULES="p/java p/kotlin p/javascript r/bash r/yaml"
           elif [[ $REPO_NAME =~ "/apple/" ]]; then
-              SEMGREP_RULES="p/ci p/javascript p/ruby p/bash p/yaml"
+              SEMGREP_RULES="p/ci p/javascript p/ruby r/bash r/yaml"
           elif [[ $REPO_NAME =~ "/web/" || $REPO_NAME =~ "/node/" ]]; then
               SEMGREP_RULES="p/javascript p/typescript"
           else
@@ -61,10 +61,23 @@ jobs:
       - name: "Checkout repository"
         uses: actions/checkout@v3
 
+      - name: "Determine base branch"
+        run: |
+          if [[ -n $(git branch --list main) ]]; then
+              echo "SEMGREP_BASELINE_REF=main" >> $GITHUB_ENV
+          elif [[ -n $(git branch --list master) ]]; then
+              echo "SEMGREP_BASELINE_REF=master" >> $GITHUB_ENV
+          else
+              echo "Could not find either main or master branch! Defaulting to HEAD^"
+              echo "SEMGREP_BASELINE_REF=HEAD^" >> $GITHUB_ENV
+              "{environment_variable_name}={value}" >> $GITHUB_ENV
+          fi
+
       - name: "Run Semgrep"
         run: "semgrep ci"
         env:
           SEMGREP_RULES: ${{ needs.set-scan-configs.outputs.SEMGREP_RULES }}
+          SEMGREP_BASELINE_REF: ${{ env.SEMGREP_BASELINE_REF }}  # enables diff-aware scans
 
   run-mobsfscan:
     name: "Run mobsfscan to find Android/iOS vulnerabilities and misconfigurations"

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     if:
       # Skip dependabot-opened PR's due to permissions issues
-      (github.actor != 'dependabot[bot]' && (contains(github.event.repository.name, "android") || contains(github.event.repository.name, "apple"))
+      (github.actor != 'dependabot[bot]' && (contains(github.event.repository.name, 'android') || contains(github.event.repository.name, 'apple'))
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -8,10 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: returntocorp/semgrep
-    if:
-      # Skip dependabot-opened PR's due to permission issues
-      # From https://semgrep.dev/docs/semgrep-ci/sample-ci-configs/#github-actions
-      (github.actor != 'dependabot[bot]')
+    if: >
+      github.actor != 'dependabot[bot]' &&
+      (contains(github.event.repository.name, 'android') || contains(github.event.repository.name, 'apple'))
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
@@ -56,9 +55,9 @@ jobs:
   run-mobsfscan:
     name: "Run mobsfscan to find Android/iOS vulnerabilities and misconfigurations"
     runs-on: ubuntu-latest
-    if:
-      # Skip dependabot-opened PR's due to permissions issues
-      (github.actor != 'dependabot[bot]' && (contains(github.event.repository.name, 'android') || contains(github.event.repository.name, 'apple'))
+    if: >
+      github.actor != 'dependabot[bot]' &&
+      ((contains(github.event.repository.name, 'android') || contains(github.event.repository.name, 'apple'))
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -1,52 +1,8 @@
 name: "Static analysis checks for security vulnerabilities"
 on:
   workflow_call:
-  pull_request:
-    types: [opened, reopened, synchronize, edited]
 
 jobs:
-  set-scan-configs:
-    name: "Determine which checks to run and set environmental variables"
-    runs-on: ubuntu-latest
-    outputs:
-      IS_MOBILE: ${{ steps.set-mobsfscan.outputs.IS_MOBILE }}
-      SEMGREP_RULES: ${{ steps.set-semgrep.outputs.SEMGREP_RULES }}
-    steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@v3
-
-      - name: "Determine which Semgrep config(s) to use"
-        id: set-semgrep
-        run: |
-          REPO_NAME=${{ github.event.repository.name }}
-
-          if [[ $REPO_NAME =~ "/android/" ]]; then
-              SEMGREP_RULES="p/java p/kotlin p/javascript r/bash r/yaml"
-          elif [[ $REPO_NAME =~ "/apple/" ]]; then
-              SEMGREP_RULES="p/ci p/javascript p/ruby r/bash r/yaml"
-          elif [[ $REPO_NAME =~ "/web/" || $REPO_NAME =~ "/node/" ]]; then
-              SEMGREP_RULES="p/javascript p/typescript"
-          else
-              SEMGREP_RULES="auto"
-          fi
-
-          echo "::set-output name=SEMGREP_RULES::$SEMGREP_RULES"
-          echo "Setting SEMGREP_RULES to \'$SEMGREP_RULES\'"
-
-      - name: "Enable mobsfscan if this is a mobile repo"
-        id: set-mobsfscan
-        run: |
-          REPO_NAME=${{ github.event.repository.name }}
-
-          if [[ $REPO_NAME =~ "/android/" || $REPO_NAME =~ "/apple/" ]]; then
-              IS_MOBILE=${{ true }}
-          else
-              IS_MOBILE=${{ false }}
-          fi
-
-          echo "::set-output name=IS_MOBILE::$IS_MOBILE"
-          echo "Setting IS_MOBILE to \'$IS_MOBILE\'"
-
   run-semgrep:
     name: "Run Semgrep to find vulnerabilities and security antipatterns"
     needs: set-scan-configs
@@ -70,13 +26,29 @@ jobs:
           else
               echo "Could not find either main or master branch! Defaulting to HEAD^"
               echo "SEMGREP_BASELINE_REF=HEAD^" >> $GITHUB_ENV
-              "{environment_variable_name}={value}" >> $GITHUB_ENV
           fi
+
+      - name: "Determine which Semgrep config(s) to use"
+        run: |
+          REPO_NAME=${{ github.event.repository.name }}
+
+          if [[ $REPO_NAME =~ "/android/" ]]; then
+              SEMGREP_RULES="p/java p/kotlin p/javascript r/bash r/yaml"
+          elif [[ $REPO_NAME =~ "/apple/" ]]; then
+              SEMGREP_RULES="p/ci p/javascript p/ruby r/bash r/yaml"
+          elif [[ $REPO_NAME =~ "/web/" || $REPO_NAME =~ "/node/" ]]; then
+              SEMGREP_RULES="p/javascript p/typescript"
+          else
+              SEMGREP_RULES="auto"
+          fi
+
+          echo "SEMGREP_RULES=$SEMGREP_RULES" >> $GITHUB_ENV
+          echo "Setting SEMGREP_RULES to \'$SEMGREP_RULES\'"
 
       - name: "Run Semgrep"
         run: "semgrep ci"
         env:
-          SEMGREP_RULES: ${{ needs.set-scan-configs.outputs.SEMGREP_RULES }}
+          SEMGREP_RULES: ${{ env.SEMGREP_RULES }}
           SEMGREP_BASELINE_REF: ${{ env.SEMGREP_BASELINE_REF }}  # enables diff-aware scans
 
   run-mobsfscan:
@@ -85,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     if:
       # Skip dependabot-opened PR's due to permissions issues
-      (needs.set-scan-configs.outputs.IS_MOBILE == format('true') && github.actor != 'dependabot[bot]')
+      (github.actor != 'dependabot[bot]')
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     if:
       # Skip dependabot-opened PR's due to permissions issues
-      (github.actor != 'dependabot[bot]')
+      (github.actor != 'dependabot[bot]' && (contains(github.event.repository.name, "android") || contains(github.event.repository.name, "apple"))
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -1,7 +1,10 @@
 name: "Static analysis checks for security vulnerabilities"
 on:
   workflow_call:
-  workflow_dispatch:
+    inputs:
+      base_branch:
+        required: true
+        type: string
 
 jobs:
   run-semgrep:
@@ -10,40 +13,25 @@ jobs:
     container:
       image: returntocorp/semgrep-action
     if: |
-      github.actor != 'dependabot[bot]' &&
-      ( contains(github.event.repository.name, 'android') || contains(github.event.repository.name, 'apple') )
+      github.actor != 'dependabot[bot]'
     steps:
-      - name: "Determine base branch"
-        run: |
-          # NOTE: This is a temporary measure in light of https://github.com/actions/runner/issues/2033
-          git config --global --add safe.directory $(pwd)
-
-          if [[ -n $(git branch --list main) ]]; then
-              echo "SEMGREP_BASELINE_REF=main" >> $GITHUB_ENV
-          elif [[ -n $(git branch --list master) ]]; then
-              echo "SEMGREP_BASELINE_REF=master" >> $GITHUB_ENV
-          else
-              echo "Could not find either main or master branch! Defaulting to HEAD^"
-              echo "SEMGREP_BASELINE_REF=HEAD^" >> $GITHUB_ENV
-          fi
-
       - name: "Checkout this branch"
         uses: actions/checkout@v3
 
       - name: "Checkout base branch"
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.SEMGREP_BASELINE_REF }}
+          ref: ${{ github.event.inputs.base_branch }}
 
       - name: "Determine which Semgrep config(s) to use"
         run: |
           REPO_NAME=${{ github.event.repository.name }}
 
-          if [[ $REPO_NAME =~ "/android/" ]]; then
+          if [[ $REPO_NAME =~ "android" ]]; then
               SEMGREP_RULES="p/java p/kotlin p/javascript r/bash r/yaml"
-          elif [[ $REPO_NAME =~ "/apple/" ]]; then
+          elif [[ $REPO_NAME =~ "apple" ]]; then
               SEMGREP_RULES="p/ci p/javascript p/ruby r/bash r/yaml"
-          elif [[ $REPO_NAME =~ "/web/" || $REPO_NAME =~ "/node/" ]]; then
+          elif [[ $REPO_NAME =~ "web" || $REPO_NAME =~ "node" ]]; then
               SEMGREP_RULES="p/javascript p/typescript"
           else
               SEMGREP_RULES="auto"
@@ -56,7 +44,7 @@ jobs:
         run: "semgrep ci"
         env:
           SEMGREP_RULES: ${{ env.SEMGREP_RULES }}
-          SEMGREP_BASELINE_REF: ${{ env.SEMGREP_BASELINE_REF }}  # enables diff-aware scans
+          SEMGREP_BASELINE_REF: ${{ github.event.inputs.base_branch }}  # enables diff-aware scans
 
   run-mobsfscan:
     name: "Run mobsfscan to find Android/iOS vulnerabilities and misconfigurations"

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -1,13 +1,14 @@
 name: "Static analysis checks for security vulnerabilities"
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   run-semgrep:
     name: "Run Semgrep to find vulnerabilities and security antipatterns"
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep
+      image: returntocorp/semgrep-action
     if: |
       github.actor != 'dependabot[bot]' &&
       ( contains(github.event.repository.name, 'android') || contains(github.event.repository.name, 'apple') )
@@ -19,6 +20,9 @@ jobs:
         run: |
           # NOTE: This is a temporary measure in light of https://github.com/actions/runner/issues/2033
           git config --global --add safe.directory $(pwd)
+
+          echo $(pwd)
+          echo $(git status)
 
           if [[ -n $(git branch --list main) ]]; then
               echo "SEMGREP_BASELINE_REF=main" >> $GITHUB_ENV

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -1,0 +1,83 @@
+name: "Static analysis checks for security vulnerabilities"
+on:
+  workflow_call:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+
+jobs:
+  set-scan-configs:
+    name: "Determine which checks to run and set environmental variables"
+    runs-on: ubuntu-latest
+    outputs:
+      IS_MOBILE: ${{ steps.set-mobsfscan.outputs.IS_MOBILE }}
+      SEMGREP_RULES: ${{ steps.set-semgrep.outputs.SEMGREP_RULES }}
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v3
+
+      - name: "Determine which Semgrep config(s) to use"
+        id: set-semgrep
+        run: |
+          REPO_NAME=${{ github.event.repository.name }}
+
+          if [[ $REPO_NAME =~ "/android/" ]]; then
+              SEMGREP_RULES="p/java p/kotlin p/javascript p/bash p/yaml"
+          elif [[ $REPO_NAME =~ "/apple/" ]]; then
+              SEMGREP_RULES="p/ci p/javascript p/ruby p/bash p/yaml"
+          elif [[ $REPO_NAME =~ "/web/" || $REPO_NAME =~ "/node/" ]]; then
+              SEMGREP_RULES="p/javascript p/typescript"
+          else
+              SEMGREP_RULES="auto"
+          fi
+
+          echo "::set-output name=SEMGREP_RULES::$SEMGREP_RULES"
+          echo "Setting SEMGREP_RULES to \'$SEMGREP_RULES\'"
+
+      - name: "Enable mobsfscan if this is a mobile repo"
+        id: set-mobsfscan
+        run: |
+          REPO_NAME=${{ github.event.repository.name }}
+
+          if [[ $REPO_NAME =~ "/android/" || $REPO_NAME =~ "/apple/" ]]; then
+              IS_MOBILE=${{ true }}
+          else
+              IS_MOBILE=${{ false }}
+          fi
+
+          echo "::set-output name=IS_MOBILE::$IS_MOBILE"
+          echo "Setting IS_MOBILE to \'$IS_MOBILE\'"
+
+  run-semgrep:
+    name: "Run Semgrep to find vulnerabilities and security antipatterns"
+    needs: set-scan-configs
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
+    if:
+      # Skip dependabot-opened PR's due to permission issues
+      # From https://semgrep.dev/docs/semgrep-ci/sample-ci-configs/#github-actions
+      (github.actor != 'dependabot[bot]')
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v3
+
+      - name: "Run Semgrep"
+        run: "semgrep ci"
+        env:
+          SEMGREP_RULES: ${{ needs.set-scan-configs.outputs.SEMGREP_RULES }}
+
+  run-mobsfscan:
+    name: "Run mobsfscan to find Android/iOS vulnerabilities and misconfigurations"
+    needs: set-scan-configs
+    runs-on: ubuntu-latest
+    if:
+      # Skip dependabot-opened PR's due to permissions issues
+      (needs.set-scan-configs.outputs.IS_MOBILE == format('true') && github.actor != 'dependabot[bot]')
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v3
+
+      - name: "Run mobsfscan"
+        uses: MobSF/mobsfscan@main
+        with:
+          args: '. --sonarqube'

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: returntocorp/semgrep
-    if: >
+    if: |
       github.actor != 'dependabot[bot]' &&
-      (contains(github.event.repository.name, 'android') || contains(github.event.repository.name, 'apple'))
+      ( contains(github.event.repository.name, 'android') || contains(github.event.repository.name, 'apple') )
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
@@ -55,9 +55,9 @@ jobs:
   run-mobsfscan:
     name: "Run mobsfscan to find Android/iOS vulnerabilities and misconfigurations"
     runs-on: ubuntu-latest
-    if: >
+    if: |
       github.actor != 'dependabot[bot]' &&
-      ((contains(github.event.repository.name, 'android') || contains(github.event.repository.name, 'apple'))
+      ( contains(github.event.repository.name, 'android') || contains(github.event.repository.name, 'apple'))
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -13,16 +13,10 @@ jobs:
       github.actor != 'dependabot[bot]' &&
       ( contains(github.event.repository.name, 'android') || contains(github.event.repository.name, 'apple') )
     steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@v3
-
       - name: "Determine base branch"
         run: |
           # NOTE: This is a temporary measure in light of https://github.com/actions/runner/issues/2033
           git config --global --add safe.directory $(pwd)
-
-          echo $(pwd)
-          echo $(git status)
 
           if [[ -n $(git branch --list main) ]]; then
               echo "SEMGREP_BASELINE_REF=main" >> $GITHUB_ENV
@@ -32,6 +26,14 @@ jobs:
               echo "Could not find either main or master branch! Defaulting to HEAD^"
               echo "SEMGREP_BASELINE_REF=HEAD^" >> $GITHUB_ENV
           fi
+
+      - name: "Checkout this branch"
+        uses: actions/checkout@v3
+
+      - name: "Checkout base branch"
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.SEMGREP_BASELINE_REF }}
 
       - name: "Determine which Semgrep config(s) to use"
         run: |

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -5,7 +5,6 @@ on:
 jobs:
   run-semgrep:
     name: "Run Semgrep to find vulnerabilities and security antipatterns"
-    needs: set-scan-configs
     runs-on: ubuntu-latest
     container:
       image: returntocorp/semgrep
@@ -53,7 +52,6 @@ jobs:
 
   run-mobsfscan:
     name: "Run mobsfscan to find Android/iOS vulnerabilities and misconfigurations"
-    needs: set-scan-configs
     runs-on: ubuntu-latest
     if:
       # Skip dependabot-opened PR's due to permissions issues

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -18,6 +18,9 @@ jobs:
 
       - name: "Determine base branch"
         run: |
+          # NOTE: This is a temporary measure in light of https://github.com/actions/runner/issues/2033
+          chown -R $(id -u):$(id -g) $PWD
+
           if [[ -n $(git branch --list main) ]]; then
               echo "SEMGREP_BASELINE_REF=main" >> $GITHUB_ENV
           elif [[ -n $(git branch --list master) ]]; then

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -18,7 +18,7 @@ jobs:
       - name: "Determine base branch"
         run: |
           # NOTE: This is a temporary measure in light of https://github.com/actions/runner/issues/2033
-          chown -R $(id -u):$(id -g) $PWD
+          git config --global --add safe.directory $(pwd)
 
           if [[ -n $(git branch --list main) ]]; then
               echo "SEMGREP_BASELINE_REF=main" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- Add reusable `semgrep` scan workflow for PR's which sets repo-specific scan configs
- Add conditional `mobsfscan` for scanning Android/iOS-based repos

## Testing Plan
- Tested workflow using my own fork on PR open, close and reopen, synchronize, and update to ensure that it triggered `semgrep` correctly and did not trigger `mobsfscan` on this repo