### PR TITLE
ci: Enable jira to github bi-directional sync

### DIFF
--- a/.github/workflows/issue-comment-to-jira.yml
+++ b/.github/workflows/issue-comment-to-jira.yml
@@ -1,5 +1,5 @@
 
-name: Create Jira Comment
+name: "Create Jira Comment"
 
 on:
   issue_comment:

--- a/.github/workflows/issue-comment-to-jira.yml
+++ b/.github/workflows/issue-comment-to-jira.yml
@@ -1,0 +1,47 @@
+
+name: Create Jira Comment
+
+on:
+  issue_comment:
+    types: ["created"]
+
+jobs:
+  issue-commented:
+    name: "Comment Issue"
+    runs-on: ubuntu-latest
+    env:
+      JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+      JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+    steps:
+      - name: "Checkout Branch"
+        uses: actions/checkout@v2
+
+      - name: "Login"
+        uses: atlassian/gajira-login@master
+
+      - name: "Get Issue"
+        id: get
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'get-issue'
+
+      - name: "Log created issue"
+        run: echo "${{ steps.get.outputs.issue-labels }}"   
+        
+      - name: Find in commit messages
+        id: find
+        uses: atlassian/gajira-find-issue-key@master
+        with:
+          string: ${{ steps.get.outputs.issue-labels }}  
+          
+      - name: "Log found issue"
+        run: |
+          echo "${{ steps.find.outputs.issue }}"  
+          echo "${{ github.event.issue }}"  
+        
+      - name: "Create comment"
+        uses: atlassian/gajira-comment@master
+        with:
+          issue: ${{ steps.find.outputs.issue }}
+          comment: ${{ github.event.comment.body }}

--- a/.github/workflows/issue-status-update-from-jira.yml
+++ b/.github/workflows/issue-status-update-from-jira.yml
@@ -1,0 +1,115 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Update Github Issue Status
+
+# Controls when the workflow will run
+on:
+  workflow_dispatch:
+    inputs:
+      jira_ticket:
+        type: string
+        description: Jira ticket number
+        required: true
+      ticket_status:
+        type: choice
+        description: Jira ticket status
+        required: true
+        options: 
+        - To Do
+        - In Progress
+        - In Review
+        - In Validation
+        - Blocked
+        - Ice Boxed
+        - Backlog
+        - Done
+        - Won't Do
+  repository_dispatch:
+
+jobs:
+  update-issue-status:
+    runs-on: ubuntu-latest
+    env:
+      JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+      JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+    steps:
+      - name: Login
+        uses: atlassian/gajira-login@master
+
+      - name: Get Jira Ticket Links
+        uses: fjogeleit/http-request-action@v1.11.0
+        id: get_links
+        with:
+          url: ${{ env.JIRA_BASE_URL }}/rest/api/2/issue/${{ github.event.inputs.jira_ticket }}/remotelink
+          method: GET
+          username: ${{ env.JIRA_USER_EMAIL }}
+          password: ${{ env.JIRA_API_TOKEN }}
+          customHeaders: '{"Content-Type": "application/json"}'
+
+      - run: echo ${{ steps.get_links.outputs.response }}
+      
+      - name: Parse URL from List
+        id: parse_url
+        run: | 
+          echo ::set-output name=issue_url::`echo '${{ steps.get_links.outputs.response }}' | jq '.[]|select(.object.title | startswith("Github Issue Link:")).object.url'`
+
+      - uses: mad9000/actions-find-and-replace-string@2
+        id: sub
+        with:
+          source: '${{ steps.parse_url.outputs.issue_url }}'
+          find: github.com
+          replace: api.github.com/repos
+
+      - run: echo  ${{ steps.sub.outputs.value }}
+      
+      - name: Set variable closed
+        id: set_variable
+        if: contains(fromJson('["Done", "Won\u0027t Do"]'), github.event.inputs.ticket_status) 
+        run: echo ::set-output name=ticket_status::closed
+
+      - name: Set Ticket Status Open
+        if: ${{ steps.set_variable.outputs.ticket_status != 'closed' }}
+        run: |
+          curl \
+          -X PATCH \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{github.token}}" \
+          ${{ steps.sub.outputs.value }} \
+          -d '{"state":"open"}'
+      
+      - name: Set Ticket Status, Wont do
+        if: contains(fromJson('["Won\u0027t Do"]'), github.event.inputs.ticket_status)
+        run: |
+          curl \
+          -X PATCH \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{github.token}}" \
+          ${{ steps.sub.outputs.value }} \
+          -d '{"state":"closed", "state_reason":"not_planned"}'
+          curl \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{github.token}}" \
+          ${{ steps.sub.outputs.value }}/comments \
+          -d '{"body":"mParticle ticket status has been changed to Wont Do"}'
+          
+      - name: Set Ticket Status Closed
+        if: ${{ steps.set_variable.outputs.ticket_status == 'closed' && (contains(fromJson('["Done"]'), github.event.inputs.ticket_status))}} 
+        run: |
+          curl \
+          -X PATCH \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{github.token}}" \
+          ${{ steps.sub.outputs.value }} \
+          -d '{"state":"closed"}'
+        
+      - name: Comment status
+        if: ${{ steps.set_variable.outputs.ticket_status != 'closed' || (contains(fromJson('["Done"]'), github.event.inputs.ticket_status))}}
+        run: |
+          curl \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{github.token}}" \
+          ${{ steps.sub.outputs.value }}/comments \
+          -d '{"body":"mParticle ticket status has been changed to ${{  github.event.inputs.ticket_status }}"}'

--- a/.github/workflows/issue-status-update-from-jira.yml
+++ b/.github/workflows/issue-status-update-from-jira.yml
@@ -74,7 +74,7 @@ jobs:
           curl \
           -X PATCH \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{github.token}}" \
+          -H "Authorization: Bearer ${{secrets.MP_SEMANTIC_RELEASE_BOT}}" \
           ${{ steps.sub.outputs.value }} \
           -d '{"state":"open"}'
       
@@ -84,13 +84,13 @@ jobs:
           curl \
           -X PATCH \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{github.token}}" \
+          -H "Authorization: Bearer ${{secrets.MP_SEMANTIC_RELEASE_BOT}}" \
           ${{ steps.sub.outputs.value }} \
           -d '{"state":"closed", "state_reason":"not_planned"}'
           curl \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{github.token}}" \
+          -H "Authorization: Bearer ${{secrets.MP_SEMANTIC_RELEASE_BOT}}" \
           ${{ steps.sub.outputs.value }}/comments \
           -d '{"body":"mParticle ticket status has been changed to Wont Do"}'
           
@@ -100,7 +100,7 @@ jobs:
           curl \
           -X PATCH \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{github.token}}" \
+          -H "Authorization: Bearer ${{secrets.MP_SEMANTIC_RELEASE_BOT}}" \
           ${{ steps.sub.outputs.value }} \
           -d '{"state":"closed"}'
         
@@ -110,6 +110,6 @@ jobs:
           curl \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{github.token}}" \
+          -H "Authorization: Bearer ${{secrets.MP_SEMANTIC_RELEASE_BOT}}" \
           ${{ steps.sub.outputs.value }}/comments \
           -d '{"body":"mParticle ticket status has been changed to ${{  github.event.inputs.ticket_status }}"}'

--- a/.github/workflows/issue-to-jira-ticket.yml
+++ b/.github/workflows/issue-to-jira-ticket.yml
@@ -1,0 +1,64 @@
+
+name: Create Jira Issue
+
+on:
+  issues:
+    types: ["opened"]
+
+jobs:
+  create-issue:
+    name: "Create Issue"
+    runs-on: ubuntu-latest
+    env:
+      JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+      JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+    steps:
+
+      - name: "Login"
+        uses: atlassian/gajira-login@master
+
+      - name: "Create"
+        id: create
+        uses: atlassian/gajira-create@master
+        with:
+          project: "SQDSDKS"
+          issuetype: "Story"
+          summary: |
+            ${{ github.event.issue.title }}
+          description: |
+            ${{ github.event.issue.body }}
+          fields: '{"parent": { "key": "SQDSDKS-4555" }}'
+      
+      - name: Link Jira Issue
+        run: |
+          curl -k -D- -u ${{ env.JIRA_USER_EMAIL }}:${{ env.JIRA_API_TOKEN }} -X POST -H 'Content-Type: application/json' -d \
+          '{"object": {"url":"${{ github.event.issue.html_url }}","title":"Github Issue Link: ${{ github.event.repository.full_name }}"}}' \
+          ${{ env.JIRA_BASE_URL }}/rest/api/2/issue/${{ steps.create.outputs.issue }}/remotelink
+          
+      - name: "Log created issue"
+        run: echo "Issue ${{ steps.create.outputs.issue }} was created"
+
+      - name: "Create Github comment"
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Tracked internally as ${{ steps.create.outputs.issue }} was created
+          reactions: '+1'
+          
+      - name: Create label
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'create-label'
+          label-name: ${{ steps.create.outputs.issue }}
+          label-color: '0095b3'
+          label-desc: ${{ steps.create.outputs.issue }} 
+          
+      - name: Add labels
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'add-labels'
+          issue-number: ${{ github.event.issue.number }} 
+          labels: ${{ steps.create.outputs.issue }}    
+         


### PR DESCRIPTION
## Summary
Uploads the hackathon yamls of 'Issues from git to jira', 'comments from git to jira' and 'status updates from jira to git'.

## Testing Plan
Do it live

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4560

