### PR TITLE
ci: fix rebase for chore/dependabot job

### DIFF
--- a/.github/workflows/dependabot-rebase-development.yml
+++ b/.github/workflows/dependabot-rebase-development.yml
@@ -7,16 +7,25 @@ jobs:
     name: "Rebase development onto chore/dependabot Branch"
     env:
       GITHUB_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
-      GIT_AUTHOR_NAME: mparticle-bot
+      GIT_AUTHOR_NAME: mparticle-automation
       GIT_AUTHOR_EMAIL: developers@mparticle.com
-      GIT_COMMITTER_NAME: mparticle-bot
+      GIT_COMMITTER_NAME: mparticle-automation
       GIT_COMMITTER_EMAIL: developers@mparticle.com
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout development branch"
         uses: actions/checkout@v2
         with:
+          token: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
           ref: development
+          fetch-depth: 0
+      - name: "Import GPG Key"
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
       - name: "Rebase chore/dependabot branch"
         run: |
           git fetch origin chore/dependabot


### PR DESCRIPTION
## Summary
- Fix rebase job for chore/dependabot
- Add missing GPG signing step

## Testing Plan
- local run showing this script working in child repo: https://github.com/mParticle/mparticle-android-sdk/actions/runs/3131289565/jobs/5082473780

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4264

