### PR TITLE
ci: fix missing repository parameter in security-hardcoded-secrets

### DIFF
--- a/.github/workflows/security-hardcoded-secrets.yml
+++ b/.github/workflows/security-hardcoded-secrets.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
           ref: ${{ github.head_ref }}
 


### PR DESCRIPTION
## Summary
- Adding missing `repository` parameter to `actions/checkout@v3`.

## Testing Plan
- Must fix [this issue](https://github.com/mParticle/mparticle-android-sdk/actions/runs/3282779232/jobs/5406637999) when merged

## Reference Issue
- Closes https://go.mparticle.com/work/SIG-478

