### PR TITLE
fix: Dependabot automerge for downloadArtifact

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -33,7 +33,7 @@ jobs:
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "pr"
             })[0];
-            var download = await github.actions.downloadArtifact({
+            var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,


### PR DESCRIPTION
## Summary
- Fix dependabot automerge for downloadArtifact

## Testing Plan
- All regression tests should pass.

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4693 
