### PR TITLE
ci: Add in ktlintCheck for kits

### DIFF
--- a/.github/workflows/android-kit-pull-request.yml
+++ b/.github/workflows/android-kit-pull-request.yml
@@ -4,36 +4,9 @@ on:
   workflow_call:
 
 jobs:
-
   pr-branch-confirmation:
-      name: "Confirm that target branch for PR is main or master"
-      runs-on: ubuntu-latest
-      steps:
-          - name: "echo PR target branch"
-            run: |
-                echo ${{ github.event.pull_request.base.ref }}
-          - name: "Set PR target branch validity"
-            id: is-valid
-            if: >
-                startsWith(github.event.pull_request.base.ref, 'development') ||
-                startsWith(github.event.pull_request.base.ref, 'build/')
-            run: |
-                OUTPUT=true
-                echo "::set-output name=isValid::$OUTPUT"
-          - name: "Echo isValid"
-            run: |
-                echo ${{ steps.is-valid.outputs.isValid }}
-          - name: "PR target branch is valid"
-            if: ${{steps.is-valid.outputs.isValid == 'true'}}
-            run: |
-                echo 'Pull request target branch is valid.'
-                echo ${{ steps.is-valid.outputs.isValid }}
-          - name: "PR target branch is invalid"
-            if: ${{ steps.is-valid.outputs.isValid != 'true'}}
-            run: |
-                echo ${{ steps.is-valid.outputs.isValid }}
-                echo 'Pull request target branch is not valid.'
-                exit 1
+    name: "Check PR for correct target branch"
+    uses: mParticle/mparticle-workflows/.github/workflows/pr-branch-target-gitflow.yml@main
 
   unit-tests:
     name: "Unit Tests"
@@ -193,20 +166,5 @@ jobs:
 
   automerge-dependabot:
     name: "Save PR Number for Dependabot Automerge"
-    needs: [ unit-tests, lint ]
-    if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout PR branch"
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          fetch-depth: 0
-      - name: "Save Pull Request Number"
-        run: |
-          mkdir -p ./pr
-          echo ${{ github.event.number }} > ./pr/NR
-      - uses: actions/upload-artifact@v3
-        with:
-          name: pr
-          path: pr/
+    needs: [ unit-tests, lint, kotlin-lint ]
+    uses: mParticle/mparticle-workflows/.github/workflows/dependabot-save-pr-number.yml@main

--- a/.github/workflows/android-kit-pull-request.yml
+++ b/.github/workflows/android-kit-pull-request.yml
@@ -15,8 +15,7 @@ jobs:
           - name: "Set PR target branch validity"
             id: is-valid
             if: >
-                startsWith(github.event.pull_request.base.ref, 'master')||
-                startsWith(github.event.pull_request.base.ref, 'main') ||
+                startsWith(github.event.pull_request.base.ref, 'development') ||
                 startsWith(github.event.pull_request.base.ref, 'build/')
             run: |
                 OUTPUT=true

--- a/.github/workflows/android-kit-pull-request.yml
+++ b/.github/workflows/android-kit-pull-request.yml
@@ -1,7 +1,10 @@
 name: "Android Kit Pull Request Checks"
-on: 
+
+on:
   workflow_call:
+
 jobs:
+
   pr-branch-confirmation:
       name: "Confirm that target branch for PR is main or master"
       runs-on: ubuntu-latest
@@ -32,6 +35,7 @@ jobs:
                 echo ${{ steps.is-valid.outputs.isValid }}
                 echo 'Pull request target branch is not valid.'
                 exit 1
+
   unit-tests:
     name: "Unit Tests"
     needs: [ pr-branch-confirmation ]
@@ -83,6 +87,7 @@ jobs:
         with:
           name: "unit-tests-results"
           path: ./**/build/reports/**
+
   lint:
     name: "Lint Checks"
     needs: [ pr-branch-confirmation ]
@@ -134,6 +139,59 @@ jobs:
         with:
           name: "lint-checks-results"
           path: ./**/build/reports/**
+
+  kotlin-lint:
+    name: "Kotlin Lint Checks"
+    needs: [ pr-branch-confirmation ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          path: kit
+          ref: ${{github.head_ref}}
+      - name: "Checkout Core"
+        uses: actions/checkout@v3
+        with:
+          repository: mParticle/android-sdk
+          fetch-depth: 0
+          path: core
+          ref: development
+      - name: "Install JDK 11"
+        uses: actions/setup-java@v3
+        with:
+          distribution: "zulu"
+          java-version: "11"
+      - name: "Build Core"
+        working-directory: core
+        run: ./gradlew publishLocal
+      - name: "Get Build Version"
+        id: core-version
+        run: |
+          ANDROID_CORE_DIR=`find  ~/.m2 -type d -name android-core`;
+          echo "android-core m2 directory:"
+          echo $ANDROID_CORE_DIR;
+          VERSION_DIR=`find $ANDROID_CORE_DIR -type d -name *-SNAPSHOT`;
+          echo "android-core m2 version directory:"
+          echo $VERSION_DIR;
+          VERSION=`basename $VERSION_DIR`;
+          echo "android-core m2 version:";
+          echo $VERSION;
+          echo "::set-output name=coreVersion::$VERSION"
+      - name: "Run Kotlin Lint Checks"
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 7.5.1
+          build-root-directory: kit
+          arguments: ktlintCheck -Pversion=${{ steps.core-version.outputs.coreVersion }}
+      - name: "Archive Kotlin Lint Results"
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: "kotlin-lint-checks-results"
+          path: ./**/build/reports/**
+
   automerge-dependabot:
     name: "Save PR Number for Dependabot Automerge"
     needs: [ unit-tests, lint ]

--- a/.github/workflows/android-kit-pull-request.yml
+++ b/.github/workflows/android-kit-pull-request.yml
@@ -4,13 +4,19 @@ on:
   workflow_call:
 
 jobs:
-  pr-branch-confirmation:
+  pr-branch-target-gitflow:
     name: "Check PR for correct target branch"
     uses: mParticle/mparticle-workflows/.github/workflows/pr-branch-target-gitflow.yml@main
+  pr-branch-check-name:
+    name: "Check PR for semantic branch name"
+    uses: mParticle/mparticle-workflows/.github/workflows/pr-branch-check-name.yml@main
+  pr-title-check:
+    name: "Check PR for semantic title"
+    uses: mParticle/mparticle-workflows/.github/workflows/pr-title-check.yml@main
 
   unit-tests:
     name: "Unit Tests"
-    needs: [ pr-branch-confirmation ]
+    needs: [ pr-branch-target-gitflow, pr-branch-check-name, pr-title-check ]
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository"

--- a/.github/workflows/android-kit-push.yml
+++ b/.github/workflows/android-kit-push.yml
@@ -1,12 +1,13 @@
 name: "Android Kit Push Checks"
+
 on:
   workflow_call:
 
 jobs:
+
   unit-tests-maven:
     name: "Unit Tests Maven"
     runs-on: ubuntu-latest
-    
     steps:
       - uses: actions/checkout@v3
       - name: "Install JDK 11"
@@ -14,6 +15,7 @@ jobs:
         with:
           distribution: "zulu"
           java-version: "11"
+          cache: "gradle"
       - name: Clean and Run Unit Tests
         continue-on-error: true
         uses: gradle/gradle-build-action@v2
@@ -26,6 +28,7 @@ jobs:
         with:
           name: "unit-tests-results-maven"
           path: ./**/build/reports/**
+
   unit-tests-development:
     name: "Unit Tests Development"
     runs-on: ubuntu-latest
@@ -48,6 +51,7 @@ jobs:
         with:
           distribution: "zulu"
           java-version: "11"
+          cache: "gradle"
       - name: "Build Core"
         working-directory: core
         run: ./gradlew publishLocal
@@ -76,6 +80,7 @@ jobs:
         with:
           name: "unit-tests-results-development"
           path: ./**/build/reports/**
+
   lint-maven:
     name: "Lint Checks Maven"
     runs-on: ubuntu-latest
@@ -90,6 +95,7 @@ jobs:
         with:
           distribution: "zulu"
           java-version: "11"
+          cache: "gradle"
       - name: "Run Lint"
         uses: gradle/gradle-build-action@v2
         continue-on-error: true
@@ -102,6 +108,7 @@ jobs:
         with:
           name: "lint-results-maven"
           path: ./**/build/reports/**
+
   lint-development:
     name: "Lint Checks Development"
     runs-on: ubuntu-latest
@@ -124,6 +131,7 @@ jobs:
         with:
           distribution: "zulu"
           java-version: "11"
+          cache: "gradle"
       - name: "Build Core"
         working-directory: core
         run: ./gradlew publishLocal
@@ -151,4 +159,84 @@ jobs:
         if: ${{ always() }}
         with:
           name: "lint-results-development"
+          path: ./**/build/reports/**
+
+  kotlin-lint-maven:
+    name: "Kotlin Lint Checks Maven"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{github.head_ref}}
+      - name: "Install JDK 11"
+        uses: actions/setup-java@v3
+        with:
+          distribution: "zulu"
+          java-version: "11"
+          cache: "gradle"
+      - name: "Run Kotlin Lint"
+        uses: gradle/gradle-build-action@v2
+        continue-on-error: true
+        with:
+          gradle-version: 7.5.1
+          arguments: ktlint
+      - name: "Archive Lint Results"
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: "kotlin-lint-results-maven"
+          path: ./**/build/reports/**
+
+  kotlin-lint-development:
+    name: "Kotlin Lint Checks Development"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          path: kit
+          ref: ${{github.head_ref}}
+      - name: "Checkout Core"
+        uses: actions/checkout@v3
+        with:
+          repository: mParticle/android-sdk
+          fetch-depth: 0
+          path: core
+          ref: development
+      - name: "Install JDK 11"
+        uses: actions/setup-java@v3
+        with:
+          distribution: "zulu"
+          java-version: "11"
+          cache: "gradle"
+      - name: "Build Core"
+        working-directory: core
+        run: ./gradlew publishLocal
+      - name: "Get Build Version"
+        id: core-version
+        run: |
+          ANDROID_CORE_DIR=`find  ~/.m2 -type d -name android-core`;
+          echo "android-core m2 directory:"
+          echo $ANDROID_CORE_DIR;
+          VERSION_DIR=`find $ANDROID_CORE_DIR -type d -name *-SNAPSHOT`;
+          echo "android-core m2 version directory:"
+          echo $VERSION_DIR;
+          VERSION=`basename $VERSION_DIR`;
+          echo "android-core m2 version:";
+          echo $VERSION;
+          echo "::set-output name=coreVersion::$VERSION"
+      - name: "Clean and Run Unit Tests"
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 7.5.1
+          build-root-directory: kit
+          arguments: ktlintCheck -Pversion=${{ steps.core-version.outputs.coreVersion }}
+      - name: "Archive Lint Results"
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: "kotlin-lint-results-development"
           path: ./**/build/reports/**

--- a/android/release.config.js
+++ b/android/release.config.js
@@ -9,15 +9,13 @@ module.exports = {
         releaseRules: [
             {type: 'feat', release: 'minor'},
             {type: 'build', release: 'minor'},
-            {type: 'fix', release: 'patch'},
-            {type: 'docs', release: 'patch'},
-            {type: 'style', release: 'patch'},
-            {type: 'refactor', release: 'patch'},
-            {type: 'perf', release: 'patch'},
-            {type: 'test', release: 'patch'},
-            {type: 'ci', release: 'patch'},
             {type: 'chore', release: 'patch'},
-            {type: 'revert', release: 'patch'}
+            {type: 'ci', release: 'patch'},
+            {type: 'docs', release: 'patch'},
+            {type: 'fix', release: 'patch'},
+            {type: 'refactor', release: 'patch'},
+            {type: 'revert', release: 'patch'},
+            {type: 'test', release: 'patch'}
        ]
       }
     ],
@@ -38,32 +36,7 @@ module.exports = {
               "hidden": false
             },
             {
-              "type": "fix",
-              "section": "Bug Fixes",
-              "hidden": false
-            },
-            {
-              "type": "docs",
-              "section": "Documentation",
-              "hidden": false
-            },
-            {
-              "type": "style",
-              "section": "Updates & Maintenance",
-              "hidden": false
-            },
-            {
-              "type": "refactor",
-              "section": "Updates & Maintenance",
-              "hidden": false
-            },
-            {
-              "type": "perf",
-              "section": "Updates & Maintenance",
-              "hidden": false
-            },
-            {
-              "type": "test",
+              "type": "chore",
               "section": "Updates & Maintenance",
               "hidden": false
             },
@@ -73,12 +46,27 @@ module.exports = {
               "hidden": false
             },
             {
-              "type": "chore",
+              "type": "docs",
+              "section": "Documentation",
+              "hidden": false
+            },
+            {
+              "type": "fix",
+              "section": "Bug Fixes",
+              "hidden": false
+            },
+            {
+              "type": "refactor",
               "section": "Updates & Maintenance",
               "hidden": false
             },
             {
               "type": "revert",
+              "section": "Updates & Maintenance",
+              "hidden": false
+            },
+            {
+              "type": "test",
               "section": "Updates & Maintenance",
               "hidden": false
             }
@@ -104,7 +92,7 @@ module.exports = {
       {
         assets: ["CHANGELOG.md", "build.gradle", "README.md"],
         message:
-          "chore: ${nextRelease.version} \n\n${nextRelease.notes}",
+          "chore: ${nextRelease.version} (release) \n\n${nextRelease.notes}",
       },
     ],
   ],


### PR DESCRIPTION
## Summary
- Add in ktlintCheck for kits
- Reorder semantic release action prefixes alphabetically 
- Android kit PRs will now target development branch

## Testing Plan
- Regression tests should pass
- We will test on a kit during a sustained engineering session

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4350

