### PR TITLE
fix:Remove potentially injectable variable from output

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -38,7 +38,7 @@ jobs:
               if: ${{ steps.is-semantic.outputs.isSemantic != 'true'}}
               run: |
                   echo ${{ steps.is-semantic.outputs.isSemantic }}
-                  echo 'Pull request title, ${{github.event.pull_request.title}} is not valid.'
+                  echo 'Pull request title is not valid.'
                   echo 'title must start with one of:'
                   echo '    build:,'
                   echo '    chore:,'


### PR DESCRIPTION
## Summary
- Removes the PR title from being echoed to output. A PR title, being user-controlled, can technically be set to something malicious (eg. `; echo $GITHUB_TOKEN_OF_CHOICE`) since it's not escaped. However, since we already have robust controls around untrusted PR environments, removing this is more of a defense-in-depth measure.

## Testing Plan
- No tests needed, just a text change.

