### PR TITLE
ci: Fix semantic release main branch check

### DIFF
--- a/.github/workflows/sdk-release-repo-branch-check.yml
+++ b/.github/workflows/sdk-release-repo-branch-check.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
 jobs:
   # SDK release must be done from the master or main branch
-  confirm-public-repo-master-branch:
+  confirm-master-main-branch:
     name: Confirm release is run on master or main branch
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sdk-release-repo-branch-check.yml
+++ b/.github/workflows/sdk-release-repo-branch-check.yml
@@ -1,25 +1,19 @@
-name: "Semantic Release Repo & Branch Check"
+name: "Semantic Release Branch Check"
 on:
   workflow_call:
 jobs:
-  # SDK release must be done from the public/master or public/main branch
+  # SDK release must be done from the master or main branch
   confirm-public-repo-master-branch:
-    name: Confirm release is run on public/master or public/main branch
+    name: Confirm release is run on master or main branch
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
 
-      - name: Repo and Branch Check
+      - name: Branch Check
         run: |
           BRANCHNAME=${GITHUB_REF##*/}
-          if (( $BRANCHNAME != "master" && $BRANCHNAME != "main" ))
-          then
+          if [ $BRANCHNAME != "master" ] && [ $BRANCHNAME != "main" ]; then
             echo "You can only run a release from the master or main branch, you are trying to run it from ${BRANCHNAME}"
-            exit 1
-          fi
-          if (( ${{github.event.repository.name}} == "*internal*" ))
-          then
-            echo "You can only run a release from the public repository of the SDK, you are trying to run it from ${{github.event.repository.name}}"
             exit 1
           fi


### PR DESCRIPTION
## Summary
- There was a bash syntax error preventing this script from parsing, and unfortunately Github would happily consider the action passed, so the check was completely nonfunctional. I've fixed the bash syntax, removed the no longer necessary check for internal repo name, and updated some naming and comments.

## Testing Plan
- Tested the script using `sh` shell to confirm the syntax is correct. It will work in all shells as I'm using the single bracket syntax.

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-5927

