### PR TITLE
ci: update github actions to latest stable version

### DIFF
--- a/.github/workflows/android-kit-push.yml
+++ b/.github/workflows/android-kit-push.yml
@@ -20,48 +20,49 @@ jobs:
     name: "Unit Tests Maven"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: "Install JDK 11"
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - name: "Install JDK 17"
+        uses: actions/setup-java@v4
         with:
           distribution: "zulu"
-          java-version: "11"
+          java-version: "17"
           cache: "gradle"
       - name: Clean and Run Unit Tests
         continue-on-error: true
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           gradle-version: 7.5.1
           arguments: clean assemble test
-      - name: "Archive Test Results"
-        uses: actions/upload-artifact@v3
+      - name: "Archive Maven Test Results"
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: "unit-tests-results-maven"
           path: ./**/build/reports/**
+          overwrite: true
 
   unit-tests-development:
     name: "Unit Tests Development"
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: kit
           ref: ${{ inputs.branch_name }}
       - name: "Checkout Core"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: mParticle/android-sdk
           fetch-depth: 0
           path: core
           ref: main
-      - name: "Install JDK 11"
-        uses: actions/setup-java@v3
+      - name: "Install JDK 17"
+        uses: actions/setup-java@v4
         with:
           distribution: "zulu"
-          java-version: "11"
+          java-version: "17"
           cache: "gradle"
       - name: "Build Core"
         working-directory: core
@@ -80,68 +81,70 @@ jobs:
           echo $VERSION;
           echo "coreVersion=$VERSION" >> $GITHUB_OUTPUT
       - name: "Clean and Run Unit Tests"
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           gradle-version: 7.5.1
           build-root-directory: kit
           arguments: clean assemble test -Pversion=${{ steps.core-version.outputs.coreVersion }}
-      - name: "Archive Test Results"
-        uses: actions/upload-artifact@v3
+      - name: "Archive Development Test Results"
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: "unit-tests-results-development"
           path: ./**/build/reports/**
+          overwrite: true
 
   lint-maven:
     name: "Lint Checks Maven"
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ inputs.branch_name }}
-      - name: "Install JDK 11"
-        uses: actions/setup-java@v3
+      - name: "Install JDK 17"
+        uses: actions/setup-java@v4
         with:
           distribution: "zulu"
-          java-version: "11"
+          java-version: "17"
           cache: "gradle"
       - name: "Run Lint"
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         continue-on-error: true
         with:
           gradle-version: 7.5.1
           arguments: lint
-      - name: "Archive Lint Results"
-        uses: actions/upload-artifact@v3
+      - name: "Archive Maven Lint Results"
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: "lint-results-maven"
           path: ./**/build/reports/**
+          overwrite: true
 
   lint-development:
     name: "Lint Checks Development"
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: kit
           ref: ${{ inputs.branch_name }}
       - name: "Checkout Core"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: mParticle/android-sdk
           fetch-depth: 0
           path: core
           ref: main
-      - name: "Install JDK 11"
-        uses: actions/setup-java@v3
+      - name: "Install JDK 17"
+        uses: actions/setup-java@v4
         with:
           distribution: "zulu"
-          java-version: "11"
+          java-version: "17"
           cache: "gradle"
       - name: "Build Core"
         working-directory: core
@@ -160,68 +163,70 @@ jobs:
           echo $VERSION;
           echo "coreVersion=$VERSION" >> $GITHUB_OUTPUT
       - name: "Clean and Run Unit Tests"
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           gradle-version: 7.5.1
           build-root-directory: kit
           arguments: lint -Pversion=${{ steps.core-version.outputs.coreVersion }}
-      - name: "Archive Lint Results"
-        uses: actions/upload-artifact@v3
+      - name: "Archive Development Lint Results"
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: "lint-results-development"
           path: ./**/build/reports/**
+          overwrite: true
 
   kotlin-lint-maven:
     name: "Kotlin Lint Checks Maven"
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ inputs.branch_name }}
-      - name: "Install JDK 11"
-        uses: actions/setup-java@v3
+      - name: "Install JDK 17"
+        uses: actions/setup-java@v4
         with:
           distribution: "zulu"
-          java-version: "11"
+          java-version: "17"
           cache: "gradle"
       - name: "Run Kotlin Lint"
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         continue-on-error: true
         with:
           gradle-version: 7.5.1
           arguments: ktlintCheck
-      - name: "Archive Lint Results"
-        uses: actions/upload-artifact@v3
+      - name: "Archive Maven Lint Results"
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: "kotlin-lint-results-maven"
           path: ./**/build/reports/**
+          overwrite: true
 
   kotlin-lint-development:
     name: "Kotlin Lint Checks Development"
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: kit
           ref: ${{ inputs.branch_name }}
       - name: "Checkout Core"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: mParticle/android-sdk
           fetch-depth: 0
           path: core
           ref: main
-      - name: "Install JDK 11"
-        uses: actions/setup-java@v3
+      - name: "Install JDK 17"
+        uses: actions/setup-java@v4
         with:
           distribution: "zulu"
-          java-version: "11"
+          java-version: "17"
           cache: "gradle"
       - name: "Build Core"
         working-directory: core
@@ -240,14 +245,15 @@ jobs:
           echo $VERSION;
           echo "coreVersion=$VERSION" >> $GITHUB_OUTPUT
       - name: "Clean and Run Unit Tests"
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           gradle-version: 7.5.1
           build-root-directory: kit
           arguments: ktlintCheck -Pversion=${{ steps.core-version.outputs.coreVersion }}
-      - name: "Archive Lint Results"
-        uses: actions/upload-artifact@v3
+      - name: "Archive Development Lint Results"
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: "kotlin-lint-results-development"
           path: ./**/build/reports/**
+          overwrite: true

--- a/.github/workflows/android-kit-release.yml
+++ b/.github/workflows/android-kit-release.yml
@@ -28,7 +28,7 @@ jobs:
       GIT_COMMITTER_EMAIL: developers@mparticle.com
     steps:
       - name: "Checkout development branch"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout main branch"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           repository: ${{ github.repository }}

--- a/.github/workflows/daily-cron.yml
+++ b/.github/workflows/daily-cron.yml
@@ -36,7 +36,7 @@ jobs:
       image: returntocorp/semgrep
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Run Semgrep"
         run: "semgrep --config=auto ."

--- a/.github/workflows/data-plan-fetch.yml
+++ b/.github/workflows/data-plan-fetch.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js
         uses: actions/setup-node@v1
@@ -53,7 +53,8 @@ jobs:
           mp planning:data-plan-versions:fetch --dataPlanId=higgs_shop_basic_data_plan --versionNumber=${{ inputs.data_plan_version }} --outFile=dataplans/${{ inputs.data_plan_id }}_${{ inputs.data_plan_version }}.json --workspaceId=$WORKSPACE_ID --clientId=$CLIENT_ID --clientSecret=$CLIENT_SECRET
 
       - name: Archive Data Plan Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: higgs-shop-dataplan
           path: ${{ inputs.app_relative_path }}/dataplans/
+          overwrite: true

--- a/.github/workflows/dependabot-rebase-development.yml
+++ b/.github/workflows/dependabot-rebase-development.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout development branch"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
           ref: development

--- a/.github/workflows/dependabot-rebase-main.yml
+++ b/.github/workflows/dependabot-rebase-main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout main branch"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: main
       - name: "Rebase chore/dependabot branch"

--- a/.github/workflows/dependabot-save-pr-number.yml
+++ b/.github/workflows/dependabot-save-pr-number.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout PR branch"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
@@ -18,7 +18,8 @@ jobs:
         run: |
           mkdir -p ./pr
           echo ${{ github.event.number }} > ./pr/NR
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: pr
           path: pr/
+          overwrite: true

--- a/.github/workflows/issue-comment-to-jira.yml
+++ b/.github/workflows/issue-comment-to-jira.yml
@@ -16,7 +16,7 @@ jobs:
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
     steps:
       - name: "Checkout Branch"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Login"
         uses: atlassian/gajira-login@master

--- a/.github/workflows/sdk-release-repo-branch-check.yml
+++ b/.github/workflows/sdk-release-repo-branch-check.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Branch Check
         run: |

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -16,10 +16,10 @@ jobs:
       github.actor != 'dependabot[bot]'
     steps:
       - name: "Checkout this branch"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Checkout base branch"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.base_branch }}
 
@@ -54,7 +54,7 @@ jobs:
       ( contains(github.event.repository.name, 'android') || contains(github.event.repository.name, 'apple'))
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Run mobsfscan"
         uses: MobSF/mobsfscan@main

--- a/.github/workflows/security-hardcoded-secrets.yml
+++ b/.github/workflows/security-hardcoded-secrets.yml
@@ -33,7 +33,7 @@ jobs:
           tar zxf "$path" -C "/tmp/bin"
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -22,15 +22,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Branch"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
           submodules: recursive
-      - name: "Set up JDK 11"
-        uses: actions/setup-java@v3
+      - name: "Set up JDK 17"
+        uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: "zulu"
           cache: "gradle"
       - name: "Cache SonarCloud packages"

--- a/.github/workflows/web-run-test.yml
+++ b/.github/workflows/web-run-test.yml
@@ -23,7 +23,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   repository: ${{ github.event.pull_request.head.repo.full_name }}
                   ref: ${{ inputs.branch_name }}
@@ -49,8 +49,9 @@ jobs:
               run: ${{ inputs.test_command }}
 
             - name: Archive npm failure logs
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               if: failure()
               with:
                   name: npm-logs
                   path: ~/.npm/_logs
+                  overwrite: true


### PR DESCRIPTION
## Summary
 - Upgrade checkout action to `v4` (`v3` is deprecated and throwing warnings)
 - Upgrade `Java 11` to `17` to match Android SDK and remove kit regression CI error

## Testing Plan
 - Check `Node.js 16` warning messages go away after next CI run
 - Check if `Java 17` change works


