### PR TITLE
ci: Add issue auto respond and close workflow

### DIFF
--- a/.github/workflows/issue-autorespond-and-close.yml
+++ b/.github/workflows/issue-autorespond-and-close.yml
@@ -1,0 +1,33 @@
+name: Respond and Close Issue
+
+on:
+  workflow_call:
+    inputs:
+      issue_number:
+        required: true
+        type: number
+      repository:
+        required: true
+        type: string
+      user_login:
+        required: true
+        type: string
+
+jobs:
+  respond_and_close:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add a comment
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ inputs.repository }}/issues/${{ inputs.issue_number }}/comments \
+            -d '{"body": "Thank you for opening this issue, @${{ github.event.issue.user.login }}!  In order to get you the fastest response to your issue, you should instead open a ticket at http://support.mparticle.com. This issue will now be automatically closed."}'
+      - name: Close the issue
+        run: |
+          curl -X PATCH \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ inputs.repository }}/issues/${{ inputs.issue_number }} \
+            -d '{"state": "closed"}'

--- a/.github/workflows/issue-autorespond-and-close.yml
+++ b/.github/workflows/issue-autorespond-and-close.yml
@@ -10,7 +10,7 @@ on:
         required: true
         type: string
       user_login:
-          description: Github Login for User who opened the issue.
+        description: Github Login for User who opened the issue.
         required: true
         type: string
 

--- a/.github/workflows/issue-autorespond-and-close.yml
+++ b/.github/workflows/issue-autorespond-and-close.yml
@@ -10,6 +10,7 @@ on:
         required: true
         type: string
       user_login:
+          description: Github Login for User who opened the issue.
         required: true
         type: string
 


### PR DESCRIPTION
## Summary
This workflow allows other `mparticle` repositories to re-use this workflow, such as https://github.com/mParticle/mparticle-web-sdk/pull/958 to automatically comment to an issue creator to redirect them to proper support channels which will make ZD tickets, which will follow our internal ticketing process better.

## Testing Plan
Tested in a personal github repository and it worked there.

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-6921