### PR TITLE
fix: Update Upload Artifact to use v4

### DIFF
--- a/.github/workflows/web-run-test.yml
+++ b/.github/workflows/web-run-test.yml
@@ -49,7 +49,7 @@ jobs:
               run: ${{ inputs.test_command }}
 
             - name: Archive npm failure logs
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               if: failure()
               with:
                   name: npm-logs


### PR DESCRIPTION
## Summary
- V3 of upload artifact has been deprecated. https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

## Testing Plan
- {explain how this has been tested, and what additional testing should be done}

## Reference Issue
- Closes https://go.mparticle.com/work/REPLACEME

