### PR TITLE
fix: Update Android Upload Artifact to use v4 And JDK 17

### DIFF
--- a/.github/workflows/android-kit-push.yml
+++ b/.github/workflows/android-kit-push.yml
@@ -21,11 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: "Install JDK 11"
+      - name: "Install JDK 17"
         uses: actions/setup-java@v3
         with:
           distribution: "zulu"
-          java-version: "11"
+          java-version: "17"
           cache: "gradle"
       - name: Clean and Run Unit Tests
         continue-on-error: true
@@ -34,7 +34,7 @@ jobs:
           gradle-version: 7.5.1
           arguments: clean assemble test
       - name: "Archive Test Results"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: "unit-tests-results-maven"
@@ -57,11 +57,11 @@ jobs:
           fetch-depth: 0
           path: core
           ref: main
-      - name: "Install JDK 11"
+      - name: "Install JDK 17"
         uses: actions/setup-java@v3
         with:
           distribution: "zulu"
-          java-version: "11"
+          java-version: "17"
           cache: "gradle"
       - name: "Build Core"
         working-directory: core
@@ -86,7 +86,7 @@ jobs:
           build-root-directory: kit
           arguments: clean assemble test -Pversion=${{ steps.core-version.outputs.coreVersion }}
       - name: "Archive Test Results"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: "unit-tests-results-development"
@@ -101,11 +101,11 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ inputs.branch_name }}
-      - name: "Install JDK 11"
+      - name: "Install JDK 17"
         uses: actions/setup-java@v3
         with:
           distribution: "zulu"
-          java-version: "11"
+          java-version: "17"
           cache: "gradle"
       - name: "Run Lint"
         uses: gradle/gradle-build-action@v2
@@ -114,7 +114,7 @@ jobs:
           gradle-version: 7.5.1
           arguments: lint
       - name: "Archive Lint Results"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: "lint-results-maven"
@@ -137,11 +137,11 @@ jobs:
           fetch-depth: 0
           path: core
           ref: main
-      - name: "Install JDK 11"
+      - name: "Install JDK 17"
         uses: actions/setup-java@v3
         with:
           distribution: "zulu"
-          java-version: "11"
+          java-version: "17"
           cache: "gradle"
       - name: "Build Core"
         working-directory: core
@@ -166,7 +166,7 @@ jobs:
           build-root-directory: kit
           arguments: lint -Pversion=${{ steps.core-version.outputs.coreVersion }}
       - name: "Archive Lint Results"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: "lint-results-development"
@@ -181,11 +181,11 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ inputs.branch_name }}
-      - name: "Install JDK 11"
+      - name: "Install JDK 17"
         uses: actions/setup-java@v3
         with:
           distribution: "zulu"
-          java-version: "11"
+          java-version: "17"
           cache: "gradle"
       - name: "Run Kotlin Lint"
         uses: gradle/gradle-build-action@v2
@@ -194,7 +194,7 @@ jobs:
           gradle-version: 7.5.1
           arguments: ktlintCheck
       - name: "Archive Lint Results"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: "kotlin-lint-results-maven"
@@ -217,11 +217,11 @@ jobs:
           fetch-depth: 0
           path: core
           ref: main
-      - name: "Install JDK 11"
+      - name: "Install JDK 17"
         uses: actions/setup-java@v3
         with:
           distribution: "zulu"
-          java-version: "11"
+          java-version: "17"
           cache: "gradle"
       - name: "Build Core"
         working-directory: core
@@ -246,7 +246,7 @@ jobs:
           build-root-directory: kit
           arguments: ktlintCheck -Pversion=${{ steps.core-version.outputs.coreVersion }}
       - name: "Archive Lint Results"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: "kotlin-lint-results-development"


### PR DESCRIPTION
## Summary
- V3 of upload artifact has been deprecated so upgrade to v4 and Upgrade JSK version to 17

## Testing Plan
- {explain how this has been tested, and what additional testing should be done}

## Reference Issue
- Closes https://go.mparticle.com/work/REPLACEME

