### PR TITLE
chore: Update dependabot-save-pr-number.yml

### DIFF
--- a/.github/workflows/dependabot-save-pr-number.yml
+++ b/.github/workflows/dependabot-save-pr-number.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout PR branch"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
@@ -18,7 +18,7 @@ jobs:
         run: |
           mkdir -p ./pr
           echo ${{ github.event.number }} > ./pr/NR
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: pr
           path: pr/


### PR DESCRIPTION
## Summary
- Dependabot [was failing](https://github.com/mparticle-integrations/mparticle-android-integration-rokt/actions/runs/15817450455/job/44579309340?pr=39) due to deprecated upload artifact. This PR bumps the versions

## Testing Plan
- N/A - no breaking changes

## Reference Issue
- Closes N/A

