### PR TITLE
Update web-kit-pull-request.yml

### DIFF
--- a/.github/workflows/web-kit-pull-request.yml
+++ b/.github/workflows/web-kit-pull-request.yml
@@ -2,8 +2,6 @@ name: Web Kit Build & Test
 
 on:
     workflow_call:
-    pull_request:
-        types: [opened, reopened, synchronize, edited]
 
 jobs:
     build-and-test:


### PR DESCRIPTION
## Summary
Propose we remove pull_request trigger as it's causing fails on [this repo](https://github.com/mParticle/mparticle-workflows/actions/workflows/web-kit-pull-request.yml).

I don't believe we need it here as it's [handled by the kits themselves](https://github.com/mparticle-integrations/mparticle-javascript-integration-bingads/blob/2757bcd242c504a8bc5dcb3b060b90adc87beb37/.github/workflows/reusable-workflows.yml#L9).

@alexs-mparticle - seeking your input specifically

## Testing Plan
- N/A

## Reference Issue
- Closes N/A

