### PR TITLE
chore: Update Sonar Cloud Java version

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -27,10 +27,10 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
           submodules: recursive
-      - name: "Set up JDK 11"
+      - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: "zulu"
           cache: "gradle"
       - name: "Cache SonarCloud packages"


### PR DESCRIPTION
## Summary
- Bump Java version used by Sonar cloud to address [this build error](https://github.com/mParticle/mparticle-android-sdk/actions/runs/16178944860/job/45670756414) as seen below:
```
org/sonar/batch/bootstrapper/EnvironmentInformation has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
```


