### PR TITLE
ci: Update Sonarcloud github token

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -13,7 +13,7 @@ jobs:
   sonarcloud-check:
     name: "SonarCloud Check"
     env:
-      GITHUB_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
+      GITHUB_TOKEN: ${{ secrets.MP_INTEGRATIONS_SEMANTIC_RELEASE_BOT }}
       GIT_AUTHOR_NAME: mparticle-automation
       GIT_AUTHOR_EMAIL: developers@mparticle.com
       GIT_COMMITTER_NAME: mparticle-automation
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
+          token: ${{ secrets.MP_INTEGRATIONS_SEMANTIC_RELEASE_BOT }}
           submodules: recursive
       - name: Set up JDK
         uses: actions/setup-java@v4


### PR DESCRIPTION
## Summary
- The old `MP_SEMANTIC_RELEASE_BOT` token has expired. It’s now replaced with the new `MP_INTEGRATIONS_SEMANTIC_RELEASE_BOT` token.

## Testing Plan
- {explain how this has been tested, and what additional testing should be done}

## Reference Issue
- Closes https://go.mparticle.com/work/REPLACEME

