### PR TITLE
ci: Update Node.js versions and action dependencies for Node 24 compa…

### DIFF
--- a/.github/workflows/android-kit-release.yml
+++ b/.github/workflows/android-kit-release.yml
@@ -34,7 +34,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: main
       - name: "Import GPG Key"
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/data-plan-fetch.yml
+++ b/.github/workflows/data-plan-fetch.yml
@@ -35,9 +35,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: '24.x'
           
       - name: Install mP CLI
         run: npm install -g @mparticle/cli

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
             echo ${{ github.event.workflow_run.event }}
       - name: 'Download artifact'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -43,7 +43,7 @@ jobs:
             fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
       - run: unzip pr.zip
       - name: 'Automerge PR'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/dependabot-rebase-development.yml
+++ b/.github/workflows/dependabot-rebase-development.yml
@@ -20,7 +20,7 @@ jobs:
           ref: development
           fetch-depth: 0
       - name: "Import GPG Key"
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/issue-comment-from-jira.yml
+++ b/.github/workflows/issue-comment-from-jira.yml
@@ -25,7 +25,7 @@ jobs:
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
     steps:
       - name: Login
-        uses: atlassian/gajira-login@master
+        uses: atlassian/gajira-login@ca13f8850ea309cf44a6e4e0c49d9aa48ac3ca4c # v3
 
       - name: Get Jira Ticket Links
         uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2.0.0
@@ -41,8 +41,9 @@ jobs:
       
       - name: Parse URL from List
         id: parse_url
-        run: | 
-          echo issue_url=`echo '${{ steps.get_links.outputs.response }}' | jq '.[]|select(.object.title | startswith("Github Issue Link:")).object.url'`
+        run: |
+          issue_url=$(echo '${{ steps.get_links.outputs.response }}' | jq -r '.[] | select(.object.title | startswith("Github Issue Link:")).object.url')
+          echo "issue_url=$issue_url" >> "$GITHUB_OUTPUT"
       
       - uses: mad9000/actions-find-and-replace-string@bf97a127285f67d542d3f06145424c64803ae81a # v2
         id: sub

--- a/.github/workflows/issue-comment-from-jira.yml
+++ b/.github/workflows/issue-comment-from-jira.yml
@@ -28,7 +28,7 @@ jobs:
         uses: atlassian/gajira-login@master
 
       - name: Get Jira Ticket Links
-        uses: fjogeleit/http-request-action@v1.11.0
+        uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2.0.0
         id: get_links
         with:
           url: ${{ env.JIRA_BASE_URL }}/rest/api/2/issue/${{ github.event.inputs.jira_ticket }}/remotelink
@@ -44,7 +44,7 @@ jobs:
         run: | 
           echo issue_url=`echo '${{ steps.get_links.outputs.response }}' | jq '.[]|select(.object.title | startswith("Github Issue Link:")).object.url'`
       
-      - uses: mad9000/actions-find-and-replace-string@2
+      - uses: mad9000/actions-find-and-replace-string@bf97a127285f67d542d3f06145424c64803ae81a # v2
         id: sub
         with:
           source: '${{ steps.parse_url.outputs.issue_url }}'

--- a/.github/workflows/issue-comment-to-jira.yml
+++ b/.github/workflows/issue-comment-to-jira.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Login"
-        uses: atlassian/gajira-login@master
+        uses: atlassian/gajira-login@ca13f8850ea309cf44a6e4e0c49d9aa48ac3ca4c # v3
 
       - name: "Get Issue"
         id: get
@@ -32,7 +32,7 @@ jobs:
         
       - name: Find in commit messages
         id: find
-        uses: atlassian/gajira-find-issue-key@master
+        uses: atlassian/gajira-find-issue-key@7d9cbdfce900a0fcf608050ce728620a928be8b6 # v3
         with:
           string: ${{ steps.get.outputs.issue-labels }}  
           
@@ -42,7 +42,7 @@ jobs:
           echo "${{ github.event.issue }}"  
         
       - name: "Create comment"
-        uses: atlassian/gajira-comment@master
+        uses: atlassian/gajira-comment@76589d6b6d0b94b1ca6b01171c01a6affb5d6701 # v3
         with:
           issue: ${{ steps.find.outputs.issue }}
           comment: ${{ github.event.comment.body }}

--- a/.github/workflows/issue-status-update-from-jira.yml
+++ b/.github/workflows/issue-status-update-from-jira.yml
@@ -37,7 +37,7 @@ jobs:
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
     steps:
       - name: Login
-        uses: atlassian/gajira-login@master
+        uses: atlassian/gajira-login@ca13f8850ea309cf44a6e4e0c49d9aa48ac3ca4c # v3
 
       - name: Get Jira Ticket Links
         uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2.0.0
@@ -53,8 +53,9 @@ jobs:
       
       - name: Parse URL from List
         id: parse_url
-        run: | 
-          echo ::set-output name=issue_url::`echo '${{ steps.get_links.outputs.response }}' | jq '.[]|select(.object.title | startswith("Github Issue Link:")).object.url'`
+        run: |
+          issue_url=$(echo '${{ steps.get_links.outputs.response }}' | jq -r '.[] | select(.object.title | startswith("Github Issue Link:")).object.url')
+          echo "issue_url=${issue_url}" >> "$GITHUB_OUTPUT"
 
       - uses: mad9000/actions-find-and-replace-string@bf97a127285f67d542d3f06145424c64803ae81a # v2
         id: sub

--- a/.github/workflows/issue-status-update-from-jira.yml
+++ b/.github/workflows/issue-status-update-from-jira.yml
@@ -40,7 +40,7 @@ jobs:
         uses: atlassian/gajira-login@master
 
       - name: Get Jira Ticket Links
-        uses: fjogeleit/http-request-action@v1.11.0
+        uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2.0.0
         id: get_links
         with:
           url: ${{ env.JIRA_BASE_URL }}/rest/api/2/issue/${{ github.event.inputs.jira_ticket }}/remotelink
@@ -56,7 +56,7 @@ jobs:
         run: | 
           echo ::set-output name=issue_url::`echo '${{ steps.get_links.outputs.response }}' | jq '.[]|select(.object.title | startswith("Github Issue Link:")).object.url'`
 
-      - uses: mad9000/actions-find-and-replace-string@2
+      - uses: mad9000/actions-find-and-replace-string@bf97a127285f67d542d3f06145424c64803ae81a # v2
         id: sub
         with:
           source: '${{ steps.parse_url.outputs.issue_url }}'

--- a/.github/workflows/issue-to-jira-ticket.yml
+++ b/.github/workflows/issue-to-jira-ticket.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
 
       - name: "Login"
-        uses: atlassian/gajira-login@master
+        uses: atlassian/gajira-login@ca13f8850ea309cf44a6e4e0c49d9aa48ac3ca4c # v3
 
       - name: "Create"
         id: create
-        uses: atlassian/gajira-create@master
+        uses: atlassian/gajira-create@1ff0b6bd115a780592b47bfbb63fc4629132e6ec # v3
         with:
           project: "SQDSDKS"
           issuetype: "Story"
@@ -31,7 +31,7 @@ jobs:
           fields: '{"parent": { "key": "SQDSDKS-4555" }}'
           
       - name: "Create First Comment"
-        uses: atlassian/gajira-comment@master
+        uses: atlassian/gajira-comment@76589d6b6d0b94b1ca6b01171c01a6affb5d6701 # v3
         with:
           issue: ${{ steps.create.outputs.issue }}
           comment: "GitHub Issue: ${{ github.event.issue.html_url }}"

--- a/.github/workflows/web-kit-pull-request.yml
+++ b/.github/workflows/web-kit-pull-request.yml
@@ -14,7 +14,7 @@ jobs:
             - name: NPM install
               uses: actions/setup-node@v4
               with:
-                  node-version: 20.x
+                  node-version: 24.x
 
             - name: Run NPM CI
               run: npm ci

--- a/.github/workflows/web-run-test.yml
+++ b/.github/workflows/web-run-test.yml
@@ -29,9 +29,9 @@ jobs:
                   ref: ${{ inputs.branch_name }}
 
             - name: NPM install
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
-                  node-version: 16.x
+                  node-version: 24.x
 
             - name: Run NPM CI
               run: npm ci
@@ -40,7 +40,7 @@ jobs:
               run: ${{ inputs.build_command }}
 
             - name: Install Firefox Latest
-              uses: browser-actions/setup-firefox@latest
+              uses: browser-actions/setup-firefox@fcf821c621167805dd63a29662bd7cb5676c81a8 # v1.7.1
 
             - name: Log Firefox Version
               run: firefox --version


### PR DESCRIPTION
…tibility

GitHub Actions runners are deprecating Node 20 in favor of Node 24. This updates application Node.js versions to 24.x and bumps third-party actions to versions that support the Node 24 runtime. Third-party actions are pinned to commit SHAs for supply chain security.

## Background
- {Explain the context of the change, including the problem it addresses or relevant background information}

## What Has Changed
- {Describe the changes introduced by this PR}

## Screenshots/Video
- {Include any screenshots or video demonstrating the new feature or fix, if applicable}

## Checklist
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes
- {Any additional information or context relevant to this PR}

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
