### PR TITLE
feat: accept scoped conventional-commit prefixes in PR title check

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -9,46 +9,32 @@ jobs:
         if: ${{ github.actor != 'dependabot[bot]' }}
         runs-on: ubuntu-latest
         steps:
-            - name: "Set PR title validity"
-              id: is-semantic
-              if: >
-                  startsWith(github.event.pull_request.title, 'feat:')||
-                  startsWith(github.event.pull_request.title, 'fix:') ||
-                  startsWith(github.event.pull_request.title, 'perf:') ||
-                  startsWith(github.event.pull_request.title, 'docs:') ||
-                  startsWith(github.event.pull_request.title, 'test:') ||
-                  startsWith(github.event.pull_request.title, 'refactor:') ||
-                  startsWith(github.event.pull_request.title, 'style:') ||
-                  startsWith(github.event.pull_request.title, 'build:') ||
-                  startsWith(github.event.pull_request.title, 'ci:') ||
-                  startsWith(github.event.pull_request.title, 'chore:') ||
-                  startsWith(github.event.pull_request.title, 'revert:')
+            - name: "Validate PR title"
+              # The title is passed through the environment (never interpolated
+              # directly into the script) to avoid shell injection.
+              env:
+                  PR_TITLE: ${{ github.event.pull_request.title }}
               run: |
-                  OUTPUT=true
-                  echo "isSemantic=$OUTPUT" >> $GITHUB_OUTPUT
-            - name: "echo isSemantic"
-              run: |
-                  echo ${{ steps.is-semantic.outputs.isSemantic }}
-            - name: "PR title is valid"
-              if: ${{steps.is-semantic.outputs.isSemantic == 'true'}}
-              run: |
-                  echo 'Pull request title is valid.'
-                  echo ${{ steps.is-semantic.outputs.isSemantic }}
-            - name: "PR title is invalid"
-              if: ${{ steps.is-semantic.outputs.isSemantic != 'true'}}
-              run: |
-                  echo ${{ steps.is-semantic.outputs.isSemantic }}
-                  echo 'Pull request title, ${{github.event.pull_request.title}} is not valid.'
-                  echo 'title must start with one of:'
-                  echo '    build:,'
-                  echo '    chore:,'
-                  echo '    ci:,'
-                  echo '    docs:,'
-                  echo '    feat:,'
-                  echo '    fix:,'
-                  echo '    perf:,'
-                  echo '    refactor:,'
-                  echo '    revert:,'
-                  echo '    style:,'
-                  echo '    test:'
-                  exit 1
+                  # A valid title starts with a conventional-commit type,
+                  # optionally followed by a scope in parentheses, then a colon:
+                  #     type:            e.g. "chore: bump dependency"
+                  #     type(scope):     e.g. "chore(rokt): bump dependency"
+                  if echo "$PR_TITLE" | grep -qE '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?:'; then
+                      echo "Pull request title is valid: $PR_TITLE"
+                  else
+                      echo "Pull request title, \"$PR_TITLE\", is not valid."
+                      echo 'Title must start with one of the following types, optionally'
+                      echo 'followed by a scope in parentheses (e.g. "feat(scope):"):'
+                      echo '    build:,'
+                      echo '    chore:,'
+                      echo '    ci:,'
+                      echo '    docs:,'
+                      echo '    feat:,'
+                      echo '    fix:,'
+                      echo '    perf:,'
+                      echo '    refactor:,'
+                      echo '    revert:,'
+                      echo '    style:,'
+                      echo '    test:'
+                      exit 1
+                  fi


### PR DESCRIPTION
## What

Adjusts the semantic PR title check (`pr-title-check.yml`) to accept **both** forms of conventional-commit prefix:

- `type:` — the bare form it already accepts (e.g. `chore: bump dependency`)
- `type(scope):` — the scoped form (e.g. `chore(rokt): bump dependency`)

Scoped titles like [`chore(rokt): bump Rokt SDK dependency to 5.3.0 (SPM + CocoaPods)`](https://github.com/mParticle/mparticle-apple-sdk/pull/796) are still valid conventional-commit titles, but the current check only matches `type:` via `startsWith(...)` and fails them.

## How

- Validation moves from a GitHub Actions expression (which supports only `startsWith` and cannot match an arbitrary scope) to a shell `grep -E` regex:
  `^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?:`
- The same set of accepted types is preserved.
- The PR title is passed via an environment variable rather than interpolated directly into `run:`, removing a script-injection risk that existed in the previous version.

## Test cases

| Title | Result |
| --- | --- |
| `chore(rokt): bump Rokt SDK dependency to 5.3.0 (SPM + CocoaPods)` | ✅ pass |
| `feat: add new event` | ✅ pass |
| `fix(identity): handle nil MPID` | ✅ pass |
| `Update README` | ❌ fail |
| `feature: not a real type` | ❌ fail |
| `chore bump without colon` | ❌ fail |

## Note on rollout

Consumer repos pin this workflow at `@stable`. This PR targets `main`; the `stable` tag needs to be advanced for consumers (e.g. `mparticle-apple-sdk`) to pick up the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)